### PR TITLE
Fix clear table functionality

### DIFF
--- a/Tests/Functional/events.spec.js
+++ b/Tests/Functional/events.spec.js
@@ -236,12 +236,12 @@ describe('Events handler Test Suite', () => {
 
 		});
 
-		it('should send updateTable when clearTable called', (done) => {
+		it('should send clear_table when clearTable called', (done) => {
 
 			var client1 = io.connect(SOCKET_URL, clientOptions);
 			var killer = killClient(client1, done);
 
-			client1.once(TableEventType.UPDATE_TABLE, () => {
+			client1.once(TableEventType.CLEAR_TABLE, () => {
 				clearTimeout(killer);
 				try {
 					expect(log.calledWith(sinon.match(patternClearTable))).to.be.true;

--- a/Tests/Functional/foosball.spec.js
+++ b/Tests/Functional/foosball.spec.js
@@ -7,18 +7,33 @@ process.env.NODE_ENV = 'test';
 
 // Dependencies
 const chai = require('chai');
+const sinon = require('sinon');
+const sinonchai = require('sinon-chai');
 const Browser = require('zombie');
 const Helpers = require('./helpers');
 const TestServer = require('./testserver');
 
 // Utils
 const expect = chai.expect;
+const assert = chai.assert;
+chai.should();
+chai.use(sinonchai);
 
 describe('Foosball Notifier Test Suite', () => {
 
 	var browser = new Browser();
-
 	let server, url, port;
+
+	let sinonbox;
+	before('Setting up sinon sandbox', () => {
+		sinonbox = sinon.sandbox.create();
+	});
+
+	afterEach('Clear sinon sandbox', () => {
+		sinonbox.restore();
+		sinonbox.resetBehavior();
+		sinonbox.reset();
+	});
 
 	before('Setting up server', (done) => {
 		try {
@@ -57,6 +72,7 @@ describe('Foosball Notifier Test Suite', () => {
 		it('should notify in chat user joined', (done) => {
 
 			expect(browser.query('#messages')).is.not.undefined;
+
 			browser
 				.fill('name', 'Frank')
 				.pressButton('Notify me!')
@@ -73,5 +89,80 @@ describe('Foosball Notifier Test Suite', () => {
 		});
 	});
 
-	//TODO: Create test for clear table
+	describe('When click clear table', () => {
+
+		it('should clear the table', (done) => {
+			expect(browser.query('#canvas1')).is.not.undefined;
+			let canvas = browser.document.getElementById('canvas1');
+			let dataUrl = '';
+			let blankDataUrl = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASwAAACWCAYAAABkW7XSAAAAxUlEQVR4nO3BMQEAAADCoPVPbQhfoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOA1v9QAATX68/0AAAAASUVORK5CYII=';
+			// Stub missing items in canvas
+			// as zombie.js through jsdom 
+			// does not support canvas
+			let ctx = canvas.getContext('2d');
+			sinonbox.stub(canvas, 'getContext')
+				.returns(ctx);
+			sinonbox.stub(ctx, 'strokeText')
+				.callsFake((name) => {
+					let prefix = 'data:image/png;base64,';
+					if (!dataUrl.startsWith(prefix)) {
+						dataUrl = prefix;
+					}
+					dataUrl += new Buffer(name)
+						.toString('base64');
+				});
+			sinonbox.stub(ctx, 'clearRect')
+				.callsFake(() => {
+					dataUrl = blankDataUrl;
+				});
+			sinonbox.stub(canvas, 'toDataURL')
+				.callsFake(() => {
+					return dataUrl;
+				});
+
+			let next = function next(idx, array) {
+				if (idx === (array.length - 1)) {
+
+					browser
+						.pressButton('Clear Table!')
+						.then(() => {
+							/**
+							 * Waiting a little bit for the
+							 * clear table to action.
+							 */
+							setTimeout(() => {
+
+								try {
+									expect(canvas).is.not.undefined;
+									assert.isFunction(canvas.toDataURL);
+									assert.isFunction(canvas.getContext);
+									assert.isObject(canvas.getContext('2d'));
+									assert.isDefined(ctx);
+									canvas.toDataURL().should.equal(blankDataUrl);
+									done();
+								} catch (e) {
+									done(e);
+								}
+							}, 10);
+
+						});
+				}
+			};
+
+			['Tester1', 'Tester2'].forEach((name, idx, array) => {
+				browser
+					.fill('name', name)
+					.pressButton('Notify me!')
+					.then(() => {
+						try {
+							assert.isDefined(canvas.toDataURL());
+							canvas.toDataURL().should.not.equal(blankDataUrl);
+							next(idx, array);
+						} catch (e) {
+							throw e;
+						}
+					});
+			});
+		});
+	});
 });

--- a/Tests/Functional/foosball.spec.js
+++ b/Tests/Functional/foosball.spec.js
@@ -72,4 +72,6 @@ describe('Foosball Notifier Test Suite', () => {
 				}).catch(done);
 		});
 	});
+
+	//TODO: Create test for clear table
 });

--- a/Tests/Functional/helpers.js
+++ b/Tests/Functional/helpers.js
@@ -4,7 +4,7 @@
 
 // Dependencies
 const chai = require('chai');
-
+const sinon = require('sinon');
 // Utils
 var expect = chai.expect;
 
@@ -25,6 +25,10 @@ var expect = chai.expect;
  */
 function mockifyCanvas(canvas) {
 
+	sinon.stub(canvas, 'tagName').get(function(){
+		return 'CANVAS';
+	});
+	
 	canvas.getContext = function() {
 		return {
 			fillRect: function() {},

--- a/Tests/Functional/helpers.js
+++ b/Tests/Functional/helpers.js
@@ -25,10 +25,10 @@ var expect = chai.expect;
  */
 function mockifyCanvas(canvas) {
 
-	sinon.stub(canvas, 'tagName').get(function(){
+	sinon.stub(canvas, 'tagName').get(function() {
 		return 'CANVAS';
 	});
-	
+
 	canvas.getContext = function() {
 		return {
 			fillRect: function() {},
@@ -76,9 +76,15 @@ module.exports = {
 				browser.wait({
 					element: '#canvas1'
 				}).then(() => {
-					// Need to mock canvas as zombie.js aka jsdom not supporting canvas
-					mockifyCanvas(browser.document.getElementById('canvas1'));
-					done();
+					/**
+					 * TODO: Investigate why timeout without
+					 * using a delay.
+					 */
+					setTimeout(() => {
+						// Need to mock canvas as zombie.js aka jsdom not supporting canvas
+						mockifyCanvas(browser.document.getElementById('canvas1'));
+						done();
+					}, 2);
 				});
 
 			}).catch(done);

--- a/components/iohandler.js
+++ b/components/iohandler.js
@@ -41,7 +41,7 @@ module.exports = function(server, table) {
 		socket.on(TableEventType.CLEAR_TABLE, function() {
 			log('Clear sent by: ' + socket.id);
 			table.clear();
-			io.emit('update_table', table.players);
+			io.emit(TableEventType.CLEAR_TABLE, table.players);
 			log('update table sent');
 		});
 

--- a/components/iohandler.spec.js
+++ b/components/iohandler.spec.js
@@ -168,7 +168,7 @@ describe('iohandler Unit Test', () => {
 
 	describe('Clear Table event', () => {
 
-		it('should update the table when clear table called', (done) => {
+		it('should send to all client when requested by one client', (done) => {
 
 			let spy = sinon.spy(table, 'clear');
 			assert.lengthOf(table.players, 0);
@@ -178,7 +178,7 @@ describe('iohandler Unit Test', () => {
 				table.players.push('Tester' + i);
 			}
 
-			client.once(TableEventType.UPDATE_TABLE, players => {
+			client.once(TableEventType.CLEAR_TABLE, players => {
 				killer.cancel();
 				spy.should.have.been.calledOnce;
 				loggerSpy.should.have.been.calledOnce;

--- a/public/js/global.js
+++ b/public/js/global.js
@@ -85,6 +85,15 @@ function addPlayerCanvas(playerName, num) {
 	ctx.strokeText(playerName, strokeArgs[0], strokeArgs[1]);
 }
 
+function clearTable(canvas){
+	if(canvas === undefined || canvas.tagName !== 'CANVAS'){
+		throw new Error('Canvas required');
+	}
+
+	let ctx = canvas.getContext('2d');
+	ctx.clearRect(0, 0, canvas.width, canvas.height);
+}
+
 function updateTable(players) {
 
 	if (players !== undefined) {
@@ -188,5 +197,9 @@ $(function() {
 	 */
 	socket.on('full_table', function() {
 		alert("Table is already full. Use the Clear button to start fresh.");
+	});
+
+	socket.on('clear_table', function(){
+		clearTable(document.getElementById('canvas1'));
 	});
 });


### PR DESCRIPTION
Due to a change made by not drawing the table image each time the table updated, the clear table functionality did not work anymore. This fix add a new event listener and new function for clearing the table.